### PR TITLE
Fix InlineKeyboardMarkup serialization

### DIFF
--- a/lib/src/impl/model.dart
+++ b/lib/src/impl/model.dart
@@ -896,7 +896,7 @@ class _InlineKeyboardMarkup extends Serializable
 
   @override
   Map<String, Object> createMap() => noNull({
-    'inline_keyboard': ll2m(inlineKeyboard, (kb) => kb._toMap()),
+    'inline_keyboard': ll2m(inlineKeyboard, (kb) => kb.toMap()),
   });
 }
 

--- a/lib/src/impl/model.dart
+++ b/lib/src/impl/model.dart
@@ -45,7 +45,13 @@ class _Update extends Serializable implements Update {
           editedMessage: _Message.fromMap(map['edited_message']),
           channelPost: _Message.fromMap(map['channel_post']),
           editedChannelPost: _Message.fromMap(map['edited_channel_post']),
-          inlineQuery: _InlineQuery.fromMap(map['inline_query']));
+          inlineQuery: _InlineQuery.fromMap(map['inline_query']),
+          chosenInlineResult: _ChosenInlineResult.fromMap(map['chosen_inline_result']),
+          callbackQuery: _CallbackQuery.fromMap(map['callback_query']),
+          shippingQuery: _ShippingQuery.fromMap(map['shipping_query']),
+          preCheckoutQuery: _PreCheckoutQuery.fromMap(map['pre_checkout_query'])
+      );
+
 
   @override
   Map<String, Object> createMap() => noNull({

--- a/lib/src/impl/util.dart
+++ b/lib/src/impl/util.dart
@@ -64,7 +64,7 @@ Iterable<O> mapOrNull<I, O>(Iterable<I> original, O mapFunction(I element)) {
   if (original == null) {
     return null;
   }
-  return original.map(mapFunction);
+  return original.map(mapFunction).toList();
 }
 
 List<Object> ls(List<Serializable> list) =>
@@ -76,7 +76,7 @@ List<List<O>> ii2ll<I, O>(Iterable<Iterable<I>> source, O convert(I from)) =>
 
 List<List<Object>> ll2m<I>(
         List<List<I>> source, Map<String, Object> convert(I from)) =>
-    mapOrNull(source, (lst) => lst.map((e) => convert(e)));
+    mapOrNull(source, (lst) => lst.map((e) => convert(e)).toList());
 
 Future<Map<String, Object>> post(
   String token,


### PR DESCRIPTION
Bug: inline keyboard doesn't work.
Reason: serialization code for InlineKeyboard contains errors.
Fixed:
1) replace call of missing `_toMap()` method of InlineKeyboard with `toMap()` inherited from `Serializable`
2) change `ll2m` function to return List instead of `MappedIterable` ([https://api.dartlang.org/stable/1.24.3/dart-core/Iterable/map.html](https://api.dartlang.org/stable/1.24.3/dart-core/Iterable/map.html)
3) do the same for `mapOrNull` method